### PR TITLE
Drop the current doc directory from the relative link fixing logic in order to "conform" to GitHub's navigation

### DIFF
--- a/viewdocs.go
+++ b/viewdocs.go
@@ -75,8 +75,7 @@ func fixRelativeLinks(doc string, repo string, ref string, body string) (string,
 						(fh >= 0 && fh < fs) {
 						continue
 					}
-					dir := path.Dir(doc)
-					n.Attr[i].Val = "/" + repoAndRef + "/" + dir + "/" + a.Val
+					n.Attr[i].Val = "/" + repoAndRef + "/" + a.Val
 				}
 			}
 		}


### PR DESCRIPTION
As I pointed on https://github.com/fgrehm/vagrant-cachier/pull/65#issuecomment-30097933, the current behavior breaks links on pages that are under folders.

For example, any relative link under http://marksteve.viewdocs.io/vagrant-cachier~docs/buckets/pacman will get the current subfolder prepended to them and this PR changes the behavior to what I think is what we get when navigating on github pages.

@marksteve my initial tests shows that things are working fine but I noticed this code was not in place during your initial work on GH-9 and that you've done that as part of https://github.com/progrium/viewdocs/commit/de8f160dc10be106a69dc9df4c6d723dbc6e95ca#diff-08c29e1209ec5d968ed1cc623ae001c8R122. Do you remember why you had to do that?
