### PR TITLE
Allow customizing a project landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ You can show documentation for different [branches](http://inconshreveable.viewd
 
 	http://<github-username>.viewdocs.io/<repository-name>~<refname>
 
-You can also customize the look and layout of your docs. Make your own `docs/template.html` based on the [default template](https://github.com/progrium/viewdocs/blob/master/docs/template.html) and your pages will be rendered with that template. 
+You can also customize the look and layout of your docs. Make your own `docs/template.html` based on the [default template](https://github.com/progrium/viewdocs/blob/master/docs/template.html) and your pages will be rendered with that template. If you create a `home.html` template, this will be used for your project's landing page.
 
 I also highly recommend you [read the source](https://github.com/progrium/viewdocs/blob/master/viewdocs.go) to this app. It's less than 200 lines of Go. If you want to hack on Viewdocs, [check this out](/viewdocs/development).
 


### PR DESCRIPTION
By creating a `home.html` template, you can override the normal `template.html` in use, which can be useful for projects where the landing page is marketing while the rest of the site is documentation.