### PR TITLE
Asset support

### DIFF
--- a/viewdocs.go
+++ b/viewdocs.go
@@ -194,6 +194,25 @@ func fetchAndRenderDoc(user, repo, ref, doc string) (string, error) {
 	return output, nil
 }
 
+func isAsset(name string) bool {
+	assetExts := map[string]bool{
+		".appcache": true,
+		".bmp":      true,
+		".css":      true,
+		".jpg":      true,
+		".jpeg":     true,
+		".js":       true,
+		".json":     true,
+		".png":      true,
+	}
+
+	if ok, _ := assetExts[path.Ext(name)]; ok {
+		return true
+	}
+
+	return false
+}
+
 func main() {
 	if os.Getenv("ACCESS_TOKEN") == "" {
 		// TODO: Add direct link to Development section of the README
@@ -229,6 +248,13 @@ func main() {
 		switch r.Method {
 		case "GET":
 			user, repo, ref, doc := parseRequest(r)
+
+			if isAsset(doc) {
+				assetUrl := "https://cdn.rawgit.com/" + user + "/" + repo + "/" + ref + "/docs/" + doc
+				http.Redirect(w, r, assetUrl, 301)
+				return
+			}
+
 			log.Printf("Building docs for '%s/%s' (ref: %s)", user, repo, ref)
 			key := user + ":" + repo + ":" + doc + ":" + ref
 			value, ok := lru.Get(key)

--- a/viewdocs.go
+++ b/viewdocs.go
@@ -100,9 +100,9 @@ func fixRelativeLinks(doc, repo, ref, body string) (string, error) {
 
 func fetchTemplate(template chan string, user string, repo string, ref string, name string) {
 	log.Println("Fetching template")
-	fetched := fetchUrl(template, "https://raw.github.com/" + user + "/" + repo + "/" + ref + "/docs/" + name + ".html")
+	fetched := fetchUrl(template, "https://raw.github.com/"+user+"/"+repo+"/"+ref+"/docs/"+name+".html")
 	if !fetched && name != "template" {
-		fetched = fetchUrl(template, "https://raw.github.com/" + user + "/" + repo + "/" + ref + "/docs/template.html")
+		fetched = fetchUrl(template, "https://raw.github.com/"+user+"/"+repo+"/"+ref+"/docs/template.html")
 	}
 
 	if !fetched {

--- a/viewdocs.go
+++ b/viewdocs.go
@@ -255,6 +255,11 @@ func main() {
 				return
 			}
 
+			if !strings.HasSuffix(r.RequestURI, "/") {
+				http.Redirect(w, r, r.RequestURI+"/", 301)
+				return
+			}
+
 			log.Printf("Building docs for '%s/%s' (ref: %s)", user, repo, ref)
 			key := user + ":" + repo + ":" + doc + ":" + ref
 			value, ok := lru.Get(key)


### PR DESCRIPTION
There are two seemingly unrelated changes here. The first adds support for assets via redirection - yay! - and the second normalizes urls. The second was necessary so I could start testing the new dokku landing page.

Semi-related question, how often is this repository deployed? Just curious so I know if/when I can deploy the new dokku documentation site.