### PR TITLE
Properly handle linking to versioned docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ You can show documentation for different [branches](http://inconshreveable.viewd
 
 You can also customize the look and layout of your docs. Make your own `docs/template.html` based on the [default template](https://github.com/progrium/viewdocs/blob/master/docs/template.html) and your pages will be rendered with that template. If you create a `home.html` template, this will be used for your project's landing page.
 
-I also highly recommend you [read the source](https://github.com/progrium/viewdocs/blob/master/viewdocs.go) to this app. It's less than 400 lines of Go. If you want to hack on Viewdocs, [check this out](/viewdocs/development).
+I also highly recommend you [read the source](https://github.com/progrium/viewdocs/blob/master/viewdocs.go) to this app. It's less than 500 lines of Go. If you want to hack on Viewdocs, [check this out](/viewdocs/development).
 
 <br />
 Enjoy!<br />

--- a/viewdocs.go
+++ b/viewdocs.go
@@ -183,8 +183,7 @@ func fetchDoc(user, repo, ref, doc string) (string, error) {
 			// special-case the index page
 			if doc == "docs/index.md" {
 				for ext := range markdownExtensions() {
-					newDoc = "README" + ext
-					bodyStr, err := fetchDoc(user, repo, ref, newDoc)
+					bodyStr, err := fetchDoc(user, repo, ref, "README"+ext)
 					return cleanupDocLinks(bodyStr, err)
 				}
 			}

--- a/viewdocs.go
+++ b/viewdocs.go
@@ -341,7 +341,7 @@ func handleRedirects(w http.ResponseWriter, r *http.Request, user string, repo s
 }
 
 func main() {
-	if os.Getenv("ACCESS_TOKEN") == "" {
+	if getenv("ACCESS_TOKEN", "") == "" {
 		log.Fatal("ACCESS_TOKEN was not found. Read http://progrium.viewdocs.io/viewdocs/development/ for more info")
 	}
 


### PR DESCRIPTION
This PR allows us to link to older doc links, which is hella useful for breaking changes...

Previously, you could externally link to a versioned copy of a given doc
page, but navigating with that version was not properly supported. This made
it difficult to provide support for major version changes within dokku.

This change does two things:

- Strips the hostname from the link
- Replaces bare repository link prefixes with a versioned link

With the former change, the following link:

    <a href="http://progrium.dokku.io/viewdocs/development">Development</a>

Becomes:

    <a href="/viewdocs/development">Development</a>

This makes it easy to do the second change (assuming the branch name `dev`):

    <a href="/viewdocs/development">Development</a>

Becomes:

    <a href="/viewdocs~dev/development">Development</a>