### PR TITLE
Redirect support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,18 @@ You can show documentation for different [branches](http://inconshreveable.viewd
 
 You can also customize the look and layout of your docs. Make your own `docs/template.html` based on the [default template](https://github.com/progrium/viewdocs/blob/master/docs/template.html) and your pages will be rendered with that template. If you create a `home.html` template, this will be used for your project's landing page.
 
+Redirects are supported for users who wish to move around files in their documentation structure. Simply create a `docs/viewdocs.json` file and specify your redirects like so:
+
+```json
+{
+    "redirects": {
+        "configuration-management": "configuration/environment-variables/"
+    }
+}
+```
+
+This will result in the url `/REPOSITORY/configuration-management/` being redirected to `/REPOSITORY/configuration/environment-variables/` url.
+
 I also highly recommend you [read the source](https://github.com/progrium/viewdocs/blob/master/viewdocs.go) to this app. It's less than 500 lines of Go. If you want to hack on Viewdocs, [check this out](/viewdocs/development).
 
 <br />


### PR DESCRIPTION
Add ability for users to specify redirects in a special `viewdocs.json` file

Redirects are in the following format:

```
{
  "redirects": {
    "original-url": "new-url"
  }
}
```

URLs are relative to the docs directory, though it is possible to redirect to an external http:// or https:// url.